### PR TITLE
Make 'v' meaningful in final weak_table test

### DIFF
--- a/missions/weak_tables.lua
+++ b/missions/weak_tables.lua
@@ -61,6 +61,7 @@ function test_really_weak_tables_have_their_mode_set_to_both_k_and_v()
   do
     local x = {}
     t[x] = x
+    t.foo = x
   end
   assert_equal(__, has_anything(t))
   collectgarbage()

--- a/src/weak_tables.lua
+++ b/src/weak_tables.lua
@@ -61,6 +61,7 @@ function test_really_weak_tables_have_their_mode_set_to_both_k_and_v()
   do
     local x = {}
     t[x] = x
+    t.foo = x
   end
   assert_equal(__(true), has_anything(t))
   collectgarbage()


### PR DESCRIPTION
Hey thanks for assembling this!

I was confused with what the last weak table test was trying to show because it is exactly the same as the test before it, while trying to figure out the difference I noticed that the existence of the `v` flag doesn't matter at all. I thought it would make it a little more meaningful if the test was changed so it actually had an effect.

(I'm running v5.2.4 if that matters at all)