### PR TITLE
Bug and typo fixes

### DIFF
--- a/missions/control.lua
+++ b/missions/control.lua
@@ -37,8 +37,8 @@ function test_if_not_statement()
 end
 
 function test_and_or_expression()
-  assert_equal( __,  (true and 'true value' or 'false value') )
-  assert_equal( __, (false and 'true value' or 'false value') )
+  assert_equal(__,  (true and 'true value' or 'false value') )
+  assert_equal(__, (false and 'true value' or 'false value') )
 end
 
 function test_while()

--- a/missions/coroutines.lua
+++ b/missions/coroutines.lua
@@ -16,7 +16,7 @@ function test_table_coroutine_contains_six_or_seven_elements()
   if lua_greater_or_equal_5_4() then
     -- if you are on Lua >=5.4
     assert_equal(__, counter)
-  else if lua_greater_or_equal_5_3() then
+  elseif lua_greater_or_equal_5_3() then
     -- if you are on Lua 5.3
     assert_equal(__, counter)
   else
@@ -136,11 +136,11 @@ function test_coroutine_running_returns_current_coroutine()
   if lua_greater_or_equal_5_2() then
     assert_equal(__, type(val1))
     assert_equal(__, type(val2))
-    assert_equal(__,  val1 == val2)
+    assert_equal(__, val1 == val2)
     assert_equal(__, val1 == val3)
     assert_equal(__, val3 == cor)
   else
-  -- In Lua 5.1 and LuaJIT, there is no "main coroutine", to coroutine.running can return nil
+  -- In Lua 5.1 and LuaJIT, there is no "main coroutine", so coroutine.running can return nil
     assert_equal(__, type(val1))
     assert_equal(__, type(val2))
     assert_equal(__, val1 == val2)

--- a/missions/indices.lua
+++ b/missions/indices.lua
@@ -50,14 +50,14 @@ end
 
 function test_index_also_works_on_integer_keys()
   local doubler = setmetatable({}, { __index = function (t, key) return key * 2 end })
-  assert_equal(__, doubler[24]) 
+  assert_equal(__, doubler[24])
 end
 
 function test_newindex_metamethod_is_invoked_when_a_new_value_is_inserted_in_a_table()
-  
+
   local t1 = {}
-  
-  local t2 = setmetatable({}, { 
+
+  local t2 = setmetatable({}, {
     __newindex = function(t, key, value)
       t1[key] = value * 10
     end
@@ -77,8 +77,8 @@ function test_newindex_syntactic_sugar_for_tables()
 end
 
 function test_rawset_allows_modifying_tables_without_invoking_newindex()
-  
-  local clock = setmetatable({}, { 
+
+  local clock = setmetatable({}, {
     __newindex = function(t, key, value)
       if key == 'hours' then
         rawset(t, 'seconds', value * 3600)

--- a/missions/tables.lua
+++ b/missions/tables.lua
@@ -7,12 +7,12 @@ local unpack = _G.unpack or table.unpack
 
 function test_creating_empty_tables()
   local empty_table = {}
-  assert_equal( __, type(empty_table))
+  assert_equal(__, type(empty_table))
 end
 
 function test_empty_tables_return_nil_when_indexed()
   local empty_table = {}
-  assert_equal( __, empty_table[1])
+  assert_equal(__, empty_table[1])
 end
 
 function test_table_modifications()
@@ -61,7 +61,7 @@ end
 
 function test_the_default_table_table()
   -- there's a table called "table". It has functions for table manipulation inside
-  assert_equal( __, type(table))
+  assert_equal(__, type(table))
 end
 
 function test_table_insert()
@@ -102,13 +102,13 @@ end
 
 function test_table_length()
   local a = { 1, 2, 3 }
-  assert_equal( __, #a)
+  assert_equal(__, #a)
 end
 
 function test_table_length_only_takes_into_account_consecutive_numbers()
   local t = { 1, 2, 3 }
   t[1000] = 1000
-  assert_equal( __, #t)
+  assert_equal(__, #t)
 end
 
 function test_using_string_as_keys()
@@ -134,7 +134,7 @@ function test_creating_an_inline_mixed_table()
   assert_equal(__, t.foo)
 end
 
-function test_non_numberic_keys_are_ignored_by_table_length()
+function test_non_numeric_keys_are_ignored_by_table_length()
   local t = { 1,2, hi = 'hello' }
   assert_equal(__, #t)
 end
@@ -146,7 +146,7 @@ end
 
 function test_using_tables_as_keys()
   local hi = { 1, 2, 3 }
-  local you = { 4, 5, 6 } 
+  local you = { 4, 5, 6 }
   local t = { [hi] = 'hello' }
   t[you] = 'world'
   assert_equal(__, t[hi])

--- a/missions/variables.lua
+++ b/missions/variables.lua
@@ -68,7 +68,7 @@ function test_boolean_type()
 end
 
 function test_table_type()
-  assert_equal(__, type({})) -- 
+  assert_equal(__, type({})) --
   -- there's lots to be learned about tables in tables.lua
 end
 


### PR DESCRIPTION
Had a lot of fun doing these, noticed these small errors and wanted to contribute fixes.

Mostly whitespace changes, a couple of typo fixes, and one actual bugfix ("else if" -> "elseif").